### PR TITLE
Refactor: Rename class attributes to lower-case.

### DIFF
--- a/osmalchemy/osmalchemy.py
+++ b/osmalchemy/osmalchemy.py
@@ -122,7 +122,7 @@ class OSMAlchemy(object):
             self._overpass = None
 
         # Generate model and store as instance members
-        self.Node, self.Way, self.Relation, self.Element = _generate_model(self._base,
+        self.node, self.way, self.relation, self.element = _generate_model(self._base,
                                                                            self._prefix)
 
         # Add triggers if online functionality is enabled

--- a/osmalchemy/triggers.py
+++ b/osmalchemy/triggers.py
@@ -61,8 +61,8 @@ def _generate_triggers(osmalchemy, maxage=60*60*24):
 
         # Check whether this query affects our model
         affected_models = set([c["type"] for c in query.column_descriptions])
-        our_models = set([osmalchemy.Node, osmalchemy.Way,  osmalchemy.Relation,
-                          osmalchemy.Element])
+        our_models = set([osmalchemy.node, osmalchemy.way,  osmalchemy.relation,
+                          osmalchemy.element])
         if affected_models.isdisjoint(our_models):
             # None of our models is affected
             return

--- a/osmalchemy/util.py
+++ b/osmalchemy/util.py
@@ -68,9 +68,9 @@ def _import_osm_dom(osma, session, dom):
             id = int(e.attributes["id"].value)
 
             # Find object in database and create if non-existent
-            node = session.query(osma.Node).filter_by(id=id).scalar()
+            node = session.query(osma.node).filter_by(id=id).scalar()
             if node is None:
-                node = osma.Node(id=id)
+                node = osma.node(id=id)
 
             # Store mandatory latitude and longitude
             node.latitude = e.attributes["lat"].value
@@ -90,15 +90,15 @@ def _import_osm_dom(osma, session, dom):
             id = int(e.attributes["id"].value)
 
             # Find object in database and create if non-existent
-            way = session.query(osma.Way).filter_by(id=id).scalar()
+            way = session.query(osma.way).filter_by(id=id).scalar()
             if way is None:
-                way = osma.Way(id=id)
+                way = osma.way(id=id)
 
             # Find all related nodes
             for n in e.getElementsByTagName("nd"):
                 # Get node id and find object
                 ref = int(n.attributes["ref"].value)
-                node = session.query(osma.Node).filter_by(id=ref).one()
+                node = session.query(osma.node).filter_by(id=ref).one()
                 # Append to nodes in way
                 way.nodes.append(node)
 
@@ -116,9 +116,9 @@ def _import_osm_dom(osma, session, dom):
             id = int(e.attributes["id"].value)
 
             # Find object in database and create if non-existent
-            relation = session.query(osma.Relation).filter_by(id=id).scalar()
+            relation = session.query(osma.relation).filter_by(id=id).scalar()
             if relation is None:
-                relation = osma.Relation(id=id)
+                relation = osma.relation(id=id)
 
             # Find all members
             for m in e.getElementsByTagName("member"):
@@ -130,15 +130,15 @@ def _import_osm_dom(osma, session, dom):
                     role = m.attributes["role"].value
                 else:
                     role = ""
-                element = session.query(osma.Element).filter_by(id=ref, type=type).scalar()
+                element = session.query(osma.element).filter_by(id=ref, type=type).scalar()
                 if element is None:
                     # We do not know the member yet, create a stub
                     if type == "node":
-                        element = osma.Node(id=ref)
+                        element = osma.node(id=ref)
                     elif type == "way":
-                        element = osma.Way(id=ref)
+                        element = osma.way(id=ref)
                     elif type == "relation":
-                        element = osma.Relation(id=ref)
+                        element = osma.relation(id=ref)
                     # We need to commit here because element could be repeated
                     session.add(element)
                     session.commit()

--- a/tests/model.py
+++ b/tests/model.py
@@ -90,7 +90,7 @@ class OSMAlchemyModelTests(object):
 
     def test_create_node(self):
         # Create node
-        node = self.osmalchemy.Node()
+        node = self.osmalchemy.node()
         node.latitude = 51.0
         node.longitude = 7.0
 
@@ -101,14 +101,14 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for node and check
-        node = self.session.query(self.osmalchemy.Node).filter_by(latitude=51.0).first()
+        node = self.session.query(self.osmalchemy.node).filter_by(latitude=51.0).first()
         self.assertEqual(node.latitude, 51.0)
         self.assertEqual(node.longitude, 7.0)
         self.assertEqual(len(node.tags), 0)
 
     def test_create_node_with_tags(self):
         # Create node and tags
-        node = self.osmalchemy.Node(51.0, 7.0)
+        node = self.osmalchemy.node(51.0, 7.0)
         node.tags = {u"name": u"test", u"foo": u"bar"}
 
         # Store everything
@@ -118,7 +118,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for node and check
-        node = self.session.query(self.osmalchemy.Node).filter_by(latitude=51.0).first()
+        node = self.session.query(self.osmalchemy.node).filter_by(latitude=51.0).first()
         self.assertEqual(node.latitude, 51.0)
         self.assertEqual(node.longitude, 7.0)
         self.assertEqual(len(node.tags), 2)
@@ -127,12 +127,12 @@ class OSMAlchemyModelTests(object):
 
     def test_create_way_with_nodes(self):
         # Create way and nodes
-        way = self.osmalchemy.Way()
-        way.nodes = [self.osmalchemy.Node(51.0, 7.0),
-                     self.osmalchemy.Node(51.1, 7.1),
-                     self.osmalchemy.Node(51.2, 7.2),
-                     self.osmalchemy.Node(51.3, 7.3),
-                     self.osmalchemy.Node(51.4, 7.4)]
+        way = self.osmalchemy.way()
+        way.nodes = [self.osmalchemy.node(51.0, 7.0),
+                     self.osmalchemy.node(51.1, 7.1),
+                     self.osmalchemy.node(51.2, 7.2),
+                     self.osmalchemy.node(51.3, 7.3),
+                     self.osmalchemy.node(51.4, 7.4)]
 
         # Store everything
         self.session.add(way)
@@ -141,7 +141,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for way and check
-        way = self.session.query(self.osmalchemy.Way).first()
+        way = self.session.query(self.osmalchemy.way).first()
         self.assertEqual(len(way.nodes), 5)
         self.assertEqual((way.nodes[0].latitude, way.nodes[0].longitude), (51.0, 7.0))
         self.assertEqual((way.nodes[1].latitude, way.nodes[1].longitude), (51.1, 7.1))
@@ -151,12 +151,12 @@ class OSMAlchemyModelTests(object):
 
     def test_create_way_with_nodes_and_tags(self):
         # Create way and nodes
-        way = self.osmalchemy.Way()
-        way.nodes = [self.osmalchemy.Node(51.0, 7.0),
-                     self.osmalchemy.Node(51.1, 7.1),
-                     self.osmalchemy.Node(51.2, 7.2),
-                     self.osmalchemy.Node(51.3, 7.3),
-                     self.osmalchemy.Node(51.4, 7.4)]
+        way = self.osmalchemy.way()
+        way.nodes = [self.osmalchemy.node(51.0, 7.0),
+                     self.osmalchemy.node(51.1, 7.1),
+                     self.osmalchemy.node(51.2, 7.2),
+                     self.osmalchemy.node(51.3, 7.3),
+                     self.osmalchemy.node(51.4, 7.4)]
         way.tags = {u"name": u"Testway", u"foo": u"bar"}
 
         # Store everything
@@ -166,7 +166,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for way and check
-        way = self.session.query(self.osmalchemy.Way).first()
+        way = self.session.query(self.osmalchemy.way).first()
         self.assertEqual(len(way.nodes), 5)
         self.assertEqual((way.nodes[0].latitude, way.nodes[0].longitude), (51.0, 7.0))
         self.assertEqual((way.nodes[1].latitude, way.nodes[1].longitude), (51.1, 7.1))
@@ -179,12 +179,12 @@ class OSMAlchemyModelTests(object):
 
     def test_create_way_with_nodes_and_tags_and_tags_on_node(self):
         # Create way and nodes
-        way = self.osmalchemy.Way()
-        way.nodes = [self.osmalchemy.Node(51.0, 7.0),
-                     self.osmalchemy.Node(51.1, 7.1),
-                     self.osmalchemy.Node(51.2, 7.2),
-                     self.osmalchemy.Node(51.3, 7.3),
-                     self.osmalchemy.Node(51.4, 7.4)]
+        way = self.osmalchemy.way()
+        way.nodes = [self.osmalchemy.node(51.0, 7.0),
+                     self.osmalchemy.node(51.1, 7.1),
+                     self.osmalchemy.node(51.2, 7.2),
+                     self.osmalchemy.node(51.3, 7.3),
+                     self.osmalchemy.node(51.4, 7.4)]
         way.tags = {u"name": u"Testway", u"foo": u"bar"}
         way.nodes[2].tags = {u"name": u"Testampel", u"foo": u"bar"}
 
@@ -195,7 +195,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for way and check
-        way = self.session.query(self.osmalchemy.Way).first()
+        way = self.session.query(self.osmalchemy.way).first()
         self.assertEqual(len(way.nodes), 5)
         self.assertEqual((way.nodes[0].latitude, way.nodes[0].longitude), (51.0, 7.0))
         self.assertEqual((way.nodes[1].latitude, way.nodes[1].longitude), (51.1, 7.1))
@@ -211,12 +211,12 @@ class OSMAlchemyModelTests(object):
 
     def test_create_relation_with_nodes(self):
         # Create way and add nodes
-        relation = self.osmalchemy.Relation()
-        relation.members = [(self.osmalchemy.Node(51.0, 7.0), u""),
-                            (self.osmalchemy.Node(51.1, 7.1), u""),
-                            (self.osmalchemy.Node(51.2, 7.2), u""),
-                            (self.osmalchemy.Node(51.3, 7.3), u""),
-                            (self.osmalchemy.Node(51.4, 7.4), u"")]
+        relation = self.osmalchemy.relation()
+        relation.members = [(self.osmalchemy.node(51.0, 7.0), u""),
+                            (self.osmalchemy.node(51.1, 7.1), u""),
+                            (self.osmalchemy.node(51.2, 7.2), u""),
+                            (self.osmalchemy.node(51.3, 7.3), u""),
+                            (self.osmalchemy.node(51.4, 7.4), u"")]
 
         # Store everything
         self.session.add(relation)
@@ -225,7 +225,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for way and check
-        relation = self.session.query(self.osmalchemy.Relation).first()
+        relation = self.session.query(self.osmalchemy.relation).first()
         self.assertEqual((relation.members[0][0].latitude, relation.members[0][0].longitude),
                          (51.0, 7.0))
         self.assertEqual((relation.members[1][0].latitude, relation.members[1][0].longitude),
@@ -239,16 +239,16 @@ class OSMAlchemyModelTests(object):
 
     def test_create_relation_with_nodes_and_ways(self):
         # Create way and add nodes and ways
-        relation = self.osmalchemy.Relation()
-        relation.members = [(self.osmalchemy.Node(51.0, 7.0), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.1, 7.1), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.2, 7.2), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.3, 7.3), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.4, 7.4), u'')]
+        relation = self.osmalchemy.relation()
+        relation.members = [(self.osmalchemy.node(51.0, 7.0), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.1, 7.1), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.2, 7.2), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.3, 7.3), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.4, 7.4), u'')]
         relation.members[3][0].nodes.append(relation.members[8][0])
 
         # Store everything
@@ -258,7 +258,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for way and check
-        relation = self.session.query(self.osmalchemy.Relation).first()
+        relation = self.session.query(self.osmalchemy.relation).first()
         self.assertEqual((relation.members[0][0].latitude, relation.members[0][0].longitude),
                          (51.0, 7.0))
         self.assertEqual((relation.members[2][0].latitude, relation.members[2][0].longitude),
@@ -273,16 +273,16 @@ class OSMAlchemyModelTests(object):
 
     def test_create_relation_with_nodes_and_ways_and_tags_everywhere(self):
         # Create way and add nodes and ways
-        relation = self.osmalchemy.Relation()
-        relation.members = [(self.osmalchemy.Node(51.0, 7.0), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.1, 7.1), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.2, 7.2), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.3, 7.3), u''),
-                            (self.osmalchemy.Way(), u''),
-                            (self.osmalchemy.Node(51.4, 7.4), u'')]
+        relation = self.osmalchemy.relation()
+        relation.members = [(self.osmalchemy.node(51.0, 7.0), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.1, 7.1), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.2, 7.2), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.3, 7.3), u''),
+                            (self.osmalchemy.way(), u''),
+                            (self.osmalchemy.node(51.4, 7.4), u'')]
         relation.tags = {u"name": u"weirdest roads in Paris"}
         relation.members[3][0].nodes.append(relation.members[8][0])
         relation.members[7][0].tags = {u"foo": u"bar", u"bang": u"baz"}
@@ -295,7 +295,7 @@ class OSMAlchemyModelTests(object):
         self.session.remove()
 
         # Query for way and check
-        relation = self.session.query(self.osmalchemy.Relation).first()
+        relation = self.session.query(self.osmalchemy.relation).first()
         self.assertEqual((relation.members[0][0].latitude, relation.members[0][0].longitude),
                          (51.0, 7.0))
         self.assertEqual((relation.members[2][0].latitude, relation.members[2][0].longitude),

--- a/tests/util.py
+++ b/tests/util.py
@@ -105,15 +105,15 @@ class OSMAlchemyUtilTests(object):
         self.session.remove()
 
         # Check number of elements
-        nodes = self.session.query(self.osmalchemy.Node).all()
-        ways = self.session.query(self.osmalchemy.Way).all()
-        relations = self.session.query(self.osmalchemy.Relation).all()
+        nodes = self.session.query(self.osmalchemy.node).all()
+        ways = self.session.query(self.osmalchemy.way).all()
+        relations = self.session.query(self.osmalchemy.relation).all()
         self.assertGreaterEqual(len(nodes), 7518)
         self.assertGreaterEqual(len(ways), 1559)
         self.assertGreaterEqual(len(relations), 33)
 
         # Try to retrieve some node and make checks on it
-        haltestelle = self.session.query(self.osmalchemy.Node).filter_by(id=252714572).one()
+        haltestelle = self.session.query(self.osmalchemy.node).filter_by(id=252714572).one()
         # Check metadata
         self.assertEqual(haltestelle.id, 252714572)
         self.assertEqual(haltestelle.latitude, 50.7509314)
@@ -123,11 +123,11 @@ class OSMAlchemyUtilTests(object):
         self.assertEqual(haltestelle.tags["VRS:ref"], "65248")
         self.assertEqual(haltestelle.tags["name"], "Schwarzrheindorf Kirche")
         # Check node on a street
-        wittestr = self.session.query(self.osmalchemy.Way).filter_by(id=23338279).one()
+        wittestr = self.session.query(self.osmalchemy.way).filter_by(id=23338279).one()
         self.assertIn(haltestelle, wittestr.nodes)
 
         # Try to retrieve some way and do checks on it
-        doppelkirche = self.session.query(self.osmalchemy.Way).filter_by(id=83296962).one()
+        doppelkirche = self.session.query(self.osmalchemy.way).filter_by(id=83296962).one()
         # Verify metadata
         self.assertEqual(doppelkirche.id, 83296962)
         self.assertEqual(doppelkirche.visible, True)
@@ -143,18 +143,18 @@ class OSMAlchemyUtilTests(object):
                  969195740, 969195742, 969195745, 969195750, 969195751, 969195752,
                  969195753, 1751858766, 969195754, 969195759, 969218844, 969195704)
         for ref in nodes:
-            nd = self.session.query(self.osmalchemy.Node).filter_by(id=ref).one()
+            nd = self.session.query(self.osmalchemy.node).filter_by(id=ref).one()
             # Verify existence
             self.assertIn(nd, doppelkirche.nodes)
             # Verify ordering
             self.assertIs(doppelkirche.nodes[nodes.index(ref)], nd)
         # Cross-check other nodes are not in way
         for ref in (26853096, 26853100, 247056873):
-            nd = self.session.query(self.osmalchemy.Node).filter_by(id=ref).one()
+            nd = self.session.query(self.osmalchemy.node).filter_by(id=ref).one()
             self.assertNotIn(nd, doppelkirche.nodes)
 
         # Try to retrieve some relation and make checks on it
-        buslinie = self.session.query(self.osmalchemy.Relation).filter_by(id=1823975).one()
+        buslinie = self.session.query(self.osmalchemy.relation).filter_by(id=1823975).one()
         # Check metadata
         self.assertEqual(buslinie.id, 1823975)
         self.assertEqual(buslinie.changeset, 40638463)


### PR DESCRIPTION
According to PEP8 class attribute names should be written lowercase.

"Use the function naming rules: lowercase with words separated by underscores as necessary to improve readability."
https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables